### PR TITLE
perf(postgresql_repo): use the official postgresql repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Content
 
-Use this role to provision postgresql
+Use this role to provision postgresql from the official postgresql repository
 
 ### Requirements
 
@@ -14,6 +14,7 @@ This role requires ubuntu
 
 The default set of variables can be used to provision databases, users and privileges and set the listen_addresses. If necessary, you can also install additional postgres packages.
 
+    postgresql_version: 16
     postgresql_listen: "0.0.0.0"
     postgresql_additional_packages:
     - postgis

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,8 @@
 ---
+postgresql_version: 16
 postgresql_listen: "localhost"
 postgresql_additional_packages: []
 postgresql_databases: []
 postgresql_users: []
 postgresql_schemas: []
-postgresql_version:
-  jammy: "14"
-  focal: "12"
-  bionic: "10"
 ...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - bionic
     - focal
     - jammy
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -32,20 +32,6 @@ platforms:
   cgroupns_mode: host
   pre_build_image: false
   dockerfile: Dockerfile.j2
-- name: ubuntu_bionic
-  image: ubuntu:18.04
-  command: ""
-  tmpfs:
-  - /tmp
-  - /run
-  - /run/lock
-  priviledged: true
-  volumes:
-  - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - /var/lib/containerd
-  cgroupns_mode: host
-  pre_build_image: false
-  dockerfile: Dockerfile.j2
 provisioner:
   name: ansible
 verifier:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,33 @@
 ---
 
+- name: APT | Install postgresql dependencies
+  ansible.builtin.apt:
+    name: "{{ packages }}"
+    state: present
+    dpkg_options: 'force-confnew,force-confdef'
+    autoclean: true
+    autoremove: true
+    update_cache: true
+    cache_valid_time: 3600
+  vars:
+    packages:
+    - curl
+    - ca-certificates
+    - gnupg
+
+- name: APT | Install gpg key
+  ansible.builtin.get_url:
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    dest: /etc/apt/trusted.gpg.d/pgdg.asc
+    mode: '0644'
+    force: true
+
+- name: Apt | Add apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release | lower }}-pgdg main"
+    state: present
+    filename: pgdg
+
 - name: Install postgresql packages
   ansible.builtin.apt:
     name: "{{ packages }}"
@@ -12,9 +40,9 @@
   vars:
     packages:
     - python3-psycopg2
-    - postgresql
-    - postgresql-client
-    - postgresql-contrib
+    - postgresql-{{ postgresql_version }}
+    - postgresql-client-{{ postgresql_version }}
+    - postgresql-contrib-{{ postgresql_version }}
     - acl
 
 - name: Install additional packages
@@ -29,7 +57,7 @@
 
 - name: Set config path
   ansible.builtin.set_fact:
-    _postgresql_config_path: "/etc/postgresql/{{ postgresql_version[ansible_distribution_release] }}/main/"
+    _postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main/"
 
 - name: Set listen_addresses
   ansible.builtin.lineinfile:


### PR DESCRIPTION
BREAKING CHANGE: postgresql version now needs to be set, as it is selectable on the official postgresql repo